### PR TITLE
refactor: change components that are using FC to PropsWhitChildren be…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "license": "MIT",
   "version": "1.0.0",
   "peerDependencies": {
-    "react": "^16.10.2 || ^17.0.0",
-    "react-dom": "^16.10.2 || ^17.0.0"
+    "react": "^16.10.2 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.10.2 || ^17.0.0 || ^18.0.0"
   },
   "author": {
     "name": "Sebastiaan Besselsen",

--- a/src/Sticky.stories.tsx
+++ b/src/Sticky.stories.tsx
@@ -1,7 +1,13 @@
 import { action } from "@storybook/addon-actions";
 import { boolean, select } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
-import React, { CSSProperties, useCallback, useRef, useState } from "react";
+import React, {
+  CSSProperties,
+  PropsWithChildren,
+  useCallback,
+  useRef,
+  useState
+} from "react";
 
 import {
   ILabels,
@@ -60,8 +66,8 @@ interface IStatefulHeaderProps {
   style?: CSSProperties;
 }
 
-const StatefulHeader: React.FC<IStatefulHeaderProps> = React.forwardRef(
-  ({ children, style = {} }, ref) => {
+const StatefulHeader = React.forwardRef(
+  ({ children, style = {} }: PropsWithChildren<IStatefulHeaderProps>, ref) => {
     const [count, setCount] = useState(0);
     const onClick = useCallback(() => {
       setCount(x => x + 1);
@@ -87,14 +93,14 @@ function fullWidth({ labels }: { labels: ILabels }) {
   return !!labels.fullWidth;
 }
 
-const StickyContent: React.FC<IStickyContentProps> = ({
+const StickyContent = ({
   behavior1,
   behavior2,
   behavior3,
   behavior4,
   behavior5,
   logLayoutInfo
-}) => {
+}: IStickyContentProps) => {
   const firstScrollTargetRef = useRef(null);
   const secondScrollTargetRef = useRef(null);
 
@@ -291,10 +297,13 @@ const fullHeightStyle = {
   height: "100%"
 };
 
-const FullHeightStickyContent: React.FC<{
+const FullHeightStickyContent = ({
+  behavior,
+  logLayoutInfo
+}: {
   behavior: IStickyBehavior;
   logLayoutInfo: boolean;
-}> = ({ behavior, logLayoutInfo }) => {
+}) => {
   useStickyLayoutListener(
     ({ getStickyLayoutInfo }) => {
       if (logLayoutInfo) {

--- a/src/components.ts
+++ b/src/components.ts
@@ -2,10 +2,10 @@ import {
   createContext,
   createElement,
   CSSProperties,
-  FC,
   Fragment,
   HTMLAttributes,
   memo,
+  PropsWithChildren,
   ReactElement,
   RefObject,
   useCallback,
@@ -47,10 +47,10 @@ export type IStickyScrollContainerProps =
     };
 
 // A container that supports scrolling with sticky elements.
-export const StickyScrollContainer: FC<IStickyScrollContainerProps> = ({
+export const StickyScrollContainer = ({
   children,
   ...props
-}) => {
+}: PropsWithChildren<IStickyScrollContainerProps>) => {
   return createElement(
     ScrollContainer,
     props,
@@ -59,7 +59,7 @@ export const StickyScrollContainer: FC<IStickyScrollContainerProps> = ({
 };
 
 // A container that supports scrolling with sticky elements.
-export const StickyContainer: FC<{}> = ({ children }) => {
+export const StickyContainer = ({ children }: PropsWithChildren<{}>) => {
   return createElement(
     GatherContainer,
     {},
@@ -77,7 +77,7 @@ export interface IStickyProps extends HTMLAttributes<HTMLDivElement> {
 const wrapperStyle = { display: "block", position: "absolute", width: "100%" };
 const placeholderStyle = { display: "block", position: "relative" };
 
-export const Sticky: FC<IStickyProps> = memo(
+export const Sticky = memo(
   ({
     behavior,
     children,
@@ -85,7 +85,7 @@ export const Sticky: FC<IStickyProps> = memo(
     respondsTo,
     defaultZIndex,
     ...attributes
-  }) => {
+  }: PropsWithChildren<IStickyProps>) => {
     const behaviorState = useRef<any>({});
     const placeholderRef = useRef<HTMLElement>();
     let ref: RefObject<HTMLElement>;
@@ -179,12 +179,12 @@ interface IStickyLayoutContext {
 
 const StickyLayoutContext = createContext<IStickyLayoutContext | null>(null);
 
-const StickyLayoutContainer: FC<{}> = ({ children }) => {
+const StickyLayoutContainer = ({ children }: PropsWithChildren<{}>) => {
   const stickyLayoutContextRef = useRef({
     listeners: [],
     getStickyLayoutInfo: () => ({ hasStickyLayout: false, bottom: 0 }),
     getStickyOffsetForY: () => 0
-  } as IStickyLayoutContext);
+  });
   return createElement(
     StickyLayoutContext.Provider,
     { value: stickyLayoutContextRef.current },
@@ -195,7 +195,7 @@ const StickyLayoutContainer: FC<{}> = ({ children }) => {
 // Calculate sticky layout info for a certain layout.
 function getStickyLayoutInfo(
   stickyLayouts: IProcessedStickyLayout[],
-  stickyHandleElements: IGatheredElement<IStickyHandle>[],
+  stickyHandleElements: Array<IGatheredElement<IStickyHandle>>,
   selector: ISelectorFunction | undefined
 ): IStickyLayoutInfo {
   let hasStickyLayout = false;
@@ -222,7 +222,7 @@ function getStickyLayoutInfo(
 }
 
 // A container that lays out sticky components and makes sure they are updated properly.
-const StickyLayoutInnerContainer: FC<{}> = ({ children }) => {
+const StickyLayoutInnerContainer = ({ children }: PropsWithChildren<{}>) => {
   const stickyLayoutContext = useContext(StickyLayoutContext);
 
   const stickyHandleElements = useGatheredElements(isStickyHandle);

--- a/src/gather.ts
+++ b/src/gather.ts
@@ -1,7 +1,7 @@
 import {
   createContext,
   createElement,
-  FC,
+  PropsWithChildren,
   RefObject,
   useContext,
   useEffect,
@@ -71,7 +71,7 @@ function sortEntries(entries: IGatherEntry[]) {
   return sortedEntries;
 }
 
-export const GatherContainer: FC<{}> = ({ children }) => {
+export const GatherContainer = ({ children }: PropsWithChildren<{}>) => {
   const [entries, setEntries] = useState<IGatherEntry[]>([]);
   const entriesValue = useMemo(() => ({ entries }), [entries]);
 

--- a/src/scroll.ts
+++ b/src/scroll.ts
@@ -3,7 +3,7 @@ import {
   createContext,
   createElement,
   CSSProperties,
-  FC,
+  PropsWithChildren,
   ReactElement,
   useCallback,
   useContext,
@@ -34,7 +34,9 @@ export type IScrollContainerProps =
 
 const defaultScrollStyle = { position: "relative", overflowY: "scroll" };
 
-export const ScrollContainer: FC<IScrollContainerProps> = props => {
+export const ScrollContainer = (
+  props: PropsWithChildren<IScrollContainerProps>
+) => {
   const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
   const ref = useCallback(
     (element: HTMLElement | null) => {


### PR DESCRIPTION
…cause since React 18 FC doesn't include children anymore in the default props

fix(package.json): adding React 18 support into peerDependencies