### PR TITLE
feat: expand zIndex handling by giving more control to the consumer

### DIFF
--- a/src/calc.ts
+++ b/src/calc.ts
@@ -30,6 +30,8 @@ export interface IStickyParameters<S = any> {
   nextElement(): IElementParameters | null;
 }
 
+export type IZIndexCalculation = (params: ICssStyleData) => number;
+
 export type IStickyBehavior<S = any> = (
   params: IStickyParameters<S>
 ) => IStickyLayout;

--- a/src/calc.ts
+++ b/src/calc.ts
@@ -30,7 +30,7 @@ export interface IStickyParameters<S = any> {
   nextElement(): IElementParameters | null;
 }
 
-export type IZIndexCalculation = (params: ICssStyleData) => number;
+export type IZIndexCalculation = (styles: ICssStyleData, layout: IProcessedStickyLayout) => number;
 
 export type IStickyBehavior<S = any> = (
   params: IStickyParameters<S>
@@ -63,7 +63,7 @@ export interface IStickyHandle {
   labels: ILabels | undefined;
   selectorFunction: ISelectorFunction | undefined;
   placeholderRef: RefObject<HTMLElement | undefined>;
-  update(stickyCopy: boolean, stickyCopyCss: ICssStyleData): void;
+  update(stickyCopy: boolean, stickyCopyCss: ICssStyleData, layout: IProcessedStickyLayout): void;
 }
 
 function memoize<T>(f: () => T): () => T {
@@ -246,7 +246,7 @@ export function updateStickyLayout(
         placeholderOffset,
         placeholderWidth
       );
-      stickyHandleElement.data.update(sticky, cssProps);
+      stickyHandleElement.data.update(sticky, cssProps, layout);
     }
   });
 
@@ -289,7 +289,7 @@ function cssifyStickyLayout(
   const sticky = true;
   const { top, z, fixedHeight } = layout;
   const { scrollTop, topOffset } = viewport();
-  const zIndex = 1000 + z;
+  const zIndex = z + 1000;
 
   if (layout.scrolling) {
     cssProps = {

--- a/src/components.ts
+++ b/src/components.ts
@@ -97,7 +97,7 @@ export const Sticky: FC<PropsWithChildren<IStickyProps>> = memo(
       selectorFunction: respondsTo,
       behaviorState: behaviorState.current,
       placeholderRef,
-      update: (sticky, stickyCssProps) => {
+      update: (_sticky, stickyCssProps, layout) => {
         const wrapper = ref.current;
         const placeholder = placeholderRef.current;
         if (!wrapper || !placeholder) {
@@ -106,12 +106,13 @@ export const Sticky: FC<PropsWithChildren<IStickyProps>> = memo(
         const wrapperCssProps: ICssStyleData = {
           ...wrapperStyle,
           ...stickyCssProps,
-          zIndex: typeof zIndex === 'undefined' ? stickyCssProps.zIndex : typeof zIndex === 'function' ? zIndex(stickyCssProps) : zIndex,
+          zIndex: typeof zIndex === 'undefined' ? stickyCssProps.zIndex : typeof zIndex === 'function' ? zIndex(stickyCssProps, layout) : zIndex,
         };
 
         for (const k of Object.keys(wrapperCssProps)) {
           wrapper.style[k as any] = wrapperCssProps[k];
         }
+        
         placeholder.style.height = wrapper.offsetHeight + "px";
         wrapper.style.width = placeholder.offsetWidth + "px";
       },

--- a/src/components.ts
+++ b/src/components.ts
@@ -69,8 +69,8 @@ export const StickyContainer: FC<PropsWithChildren<{}>> = ({ children }) => {
 };
 
 export interface IStickyProps extends HTMLAttributes<HTMLDivElement> {
-  zIndex: IZIndexCalculation | number;
   behavior: IStickyBehavior;
+  zIndex?: IZIndexCalculation | number;
   labels?: ILabels;
   respondsTo?: ISelectorFunction;
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -21,6 +21,7 @@ import {
   IProcessedStickyLayout,
   IStickyBehavior,
   IStickyHandle,
+  IZIndexCalculation,
   updateStickyLayout,
 } from "./calc";
 import {
@@ -68,7 +69,7 @@ export const StickyContainer: FC<PropsWithChildren<{}>> = ({ children }) => {
 };
 
 export interface IStickyProps extends HTMLAttributes<HTMLDivElement> {
-  defaultZIndex?: number;
+  zIndex: IZIndexCalculation | number;
   behavior: IStickyBehavior;
   labels?: ILabels;
   respondsTo?: ISelectorFunction;
@@ -79,16 +80,17 @@ const placeholderStyle = { display: "block", position: "relative" };
 
 export const Sticky: FC<PropsWithChildren<IStickyProps>> = memo(
   ({
+    zIndex,
     behavior,
     children,
     labels,
     respondsTo,
-    defaultZIndex,
     ...attributes
   }) => {
     const behaviorState = useRef<any>({});
     const placeholderRef = useRef<HTMLElement>();
     let ref: RefObject<HTMLElement>;
+
     const handle: IStickyHandle = {
       behavior,
       labels,
@@ -104,10 +106,7 @@ export const Sticky: FC<PropsWithChildren<IStickyProps>> = memo(
         const wrapperCssProps: ICssStyleData = {
           ...wrapperStyle,
           ...stickyCssProps,
-          ...(!sticky &&
-            defaultZIndex !== undefined && {
-              zIndex: defaultZIndex,
-            }),
+          zIndex: typeof zIndex === 'undefined' ? stickyCssProps.zIndex : typeof zIndex === 'function' ? zIndex(stickyCssProps) : zIndex,
         };
 
         for (const k of Object.keys(wrapperCssProps)) {


### PR DESCRIPTION
hey there, long time no see ~

In our project we would like to have a bit more control over the zIndex per Sticky instead of only having control over the zIndex when the element hasn't been reached yet (defaultZIndex)

In order to facilitate this, I made the following adjustment:

* Removed the defaultZIndex
* added an optional zIndex prop, which can either be a function or a number (for both calculated and absolute control), we pass both the calculated styles as well as layout for allowing the consumer to pass their own calculation

for example, we would like to do this:

```
<Sticky zIndex={(, layout ) => theme.zIndices.base + layout.z )} />
```

This way, we don't have to up the zIndices for our design system just to ensure that some things stay on top of the <Sticky> elements (for example: modal overlays need to go over the sticky elements, but in our theme they are defined as sub 1000)